### PR TITLE
list/fix-icon

### DIFF
--- a/packages/list/src/mwc-list-item.scss
+++ b/packages/list/src/mwc-list-item.scss
@@ -17,7 +17,7 @@ limitations under the License.
 
 @import '@material/list/mdc-list.scss';
 @import "@material/ripple/mixins";
-@import '@material/mwc-icon/src/mwc-icon-host.scss';
+@import '@material/mwc-icon/src/_mwc-icon.scss';
 
 .material-icons {
   @extend %material-icons;


### PR DESCRIPTION
Please, merge to prevent the `--mdc-icon-font` from being applied to the entire `mwc-list-item` (including primary and secondary text).